### PR TITLE
Updates correct library name on the arduino library manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Tested and works great with the Adafruit PM2.5 Air Quality Sensor and Breadboard
 Adafruit invests time and resources providing this open source code, please support Adafruit and open-source hardware by purchasing products from Adafruit!
 
 # Installation
-To install, use the Arduino Library Manager and search for "Adafruit PM25AQI" and install the library.
+To install, use the Arduino Library Manager and search for "Adafruit PM25 AQI" and install the library.
 
 ## Dependencies
  * [Adafruit BusIO](https://github.com/adafruit/Adafruit_BusIO)


### PR DESCRIPTION
Searching for `Adafruit PM25AQI` yields no results.

<img width="912" alt="Screen Shot 2020-09-05 at 1 14 52 AM" src="https://user-images.githubusercontent.com/1854811/92301083-581f0100-ef15-11ea-8ee3-ccb91712eca8.png">

Searching for `Adafruit PM25 AQI` yields results.

<img width="912" alt="Screen Shot 2020-09-05 at 1 14 49 AM" src="https://user-images.githubusercontent.com/1854811/92301090-679e4a00-ef15-11ea-9b3c-337d595f3e88.png">

