### PR TITLE
Fixed typo in serial text output

### DIFF
--- a/examples/PM25_test/PM25_test.ino
+++ b/examples/PM25_test/PM25_test.ino
@@ -65,7 +65,7 @@ void loop() {
   Serial.print(F("Particles > 1.0um / 0.1L air:")); Serial.println(data.particles_10um);
   Serial.print(F("Particles > 2.5um / 0.1L air:")); Serial.println(data.particles_25um);
   Serial.print(F("Particles > 5.0um / 0.1L air:")); Serial.println(data.particles_50um);
-  Serial.print(F("Particles > 50 um / 0.1L air:")); Serial.println(data.particles_100um);
+  Serial.print(F("Particles > 10 um / 0.1L air:")); Serial.println(data.particles_100um);
   Serial.println(F("---------------------------------------"));
   
 


### PR DESCRIPTION
Fix typo in example sketch that indicated wrong unit value

Can use Plantower datasheets as source of truth for unit values:
https://cdn-shop.adafruit.com/product-files/3686/plantower-pms5003-manual_v2-3.pdf
https://cdn-shop.adafruit.com/product-files/4632/4505_PMSA003I_series_data_manual_English_V2.6.pdf

