### PR TITLE
More reliable serial read from PM2.5 sensor.

### DIFF
--- a/Adafruit_PM25AQI.cpp
+++ b/Adafruit_PM25AQI.cpp
@@ -88,7 +88,7 @@ bool Adafruit_PM25AQI::read(PM25_AQI_Data *data) {
       serial_dev->read();
       skipped++;
       if (!serial_dev->available()) {
-	return false;
+        return false;
       }
     }
     if (serial_dev->peek() != 0x42) {

--- a/Adafruit_PM25AQI.cpp
+++ b/Adafruit_PM25AQI.cpp
@@ -83,10 +83,10 @@ bool Adafruit_PM25AQI::read(PM25_AQI_Data *data) {
     if (!serial_dev->available()) {
       return false;
     }
-    for (int skipped = 0;
-	 (skipped < 32) && (serial_dev->peek() != 0x42);
-	 skipped++) {
+    int skipped = 0;
+    while ( (skipped < 32) && (serial_dev->peek() != 0x42) ) {
       serial_dev->read();
+      skipped++;
       if (!serial_dev->available()) {
 	return false;
       }

--- a/Adafruit_PM25AQI.cpp
+++ b/Adafruit_PM25AQI.cpp
@@ -84,7 +84,7 @@ bool Adafruit_PM25AQI::read(PM25_AQI_Data *data) {
       return false;
     }
     int skipped = 0;
-    while ( (skipped < 32) && (serial_dev->peek() != 0x42) ) {
+    while ((skipped < 32) && (serial_dev->peek() != 0x42)) {
       serial_dev->read();
       skipped++;
       if (!serial_dev->available()) {

--- a/Adafruit_PM25AQI.cpp
+++ b/Adafruit_PM25AQI.cpp
@@ -83,6 +83,14 @@ bool Adafruit_PM25AQI::read(PM25_AQI_Data *data) {
     if (!serial_dev->available()) {
       return false;
     }
+    for (int skipped = 0;
+	 (skipped < 32) && (serial_dev->peek() != 0x42);
+	 skipped++) {
+      serial_dev->read();
+      if (!serial_dev->available()) {
+	return false;
+      }
+    }
     if (serial_dev->peek() != 0x42) {
       serial_dev->read();
       return false;


### PR DESCRIPTION
- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**  This will help us understand any risks of integrating
  the code.

This changes serial reads from the PM2.5 sensor to scan buffered input (up to one
message's worth of bytes), looking for the header byte.  It bails out if no data is available, or
after the magic start byte isn't found within a message's worth of bytes, to avoid 
hanging.  Depending on the delays callers add between read attempts, this can reduce
 failed reads significantly

- **Describe any known limitations with your change.**  For example if the change
  doesn't apply to a supported platform of the library please mention it.

The modified version should work on any platform - it will probably make the biggest
difference on devices with limited buffering and/or software serial (I see big differences
in read-failure rates using software serial on a HUZZAH ESP8266).

- **Please run any tests or examples that can exercise your modified code.**  We
  strive to not break users of the code and running tests/examples helps with this
  process.

I have run the test program (as well as my own), and I see much more reliable reads with the 
changed version. 

