### PR TITLE
Correct struct comments so that it matches data sheet

### DIFF
--- a/Adafruit_PM25AQI.h
+++ b/Adafruit_PM25AQI.h
@@ -35,12 +35,12 @@ typedef struct PMSAQIdata {
   uint16_t pm10_env,       ///< Environmental PM1.0
       pm25_env,            ///< Environmental PM2.5
       pm100_env;           ///< Environmental PM10.0
-  uint16_t particles_03um, ///< 0.3um Particle Count
-      particles_05um,      ///< 0.5um Particle Count
-      particles_10um,      ///< 1.0um Particle Count
-      particles_25um,      ///< 2.5um Particle Count
-      particles_50um,      ///< 5.0um Particle Count
-      particles_100um;     ///< 10.0um Particle Count
+  uint16_t particles_03um, ///> 0.3um Particle Count
+      particles_05um,      ///> 0.5um Particle Count
+      particles_10um,      ///> 1.0um Particle Count
+      particles_25um,      ///> 2.5um Particle Count
+      particles_50um,      ///> 5.0um Particle Count
+      particles_100um;     ///> 10.0um Particle Count
   uint16_t unused;         ///< Unused
   uint16_t checksum;       ///< Packet checksum
 } PM25_AQI_Data;


### PR DESCRIPTION
**SCOPE**

Changes comments on the struct

**DESCRIPTION**

The current struct comments do not match the data sheet. The comment should be changed to say "> 0.3um Particle Count" etc.

The data sheet says:

> indicates the number of particles with diameter beyond 0.3 μ𝑚 in 0.1L of air


![https___cdn-shop_adafruit_com_product-files_4632_4505_PMSA003I_series_data_manual_English_V2_6_pdf_a](https://user-images.githubusercontent.com/3364754/104828798-22295a80-58c1-11eb-905d-54d087d5568e.png)
