### PR TITLE
Fix typo in githubci.yml

### DIFF
--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -28,5 +28,5 @@ jobs:
     - name: doxygen
       env:
         GH_REPO_TOKEN: ${{ secrets.GH_REPO_TOKEN }}
-        PRETTYNAME : "Adafruit SGP30 Arduino Library"
+        PRETTYNAME : "Adafruit PM25AQI Arduino Library"
       run: bash ci/doxy_gen_and_deploy.sh


### PR DESCRIPTION
This merge request fixes a simple typo in the Github CI file that I noticed when I was looking at it.
The project pretty name field references a different Adafruit project. 
This file was probably copied from another Adafruit project and the update to the project name was missed.