### PR TITLE
Fixing 1 in 256 edge-case that can lead to continuous no-output.

### DIFF
--- a/Adafruit_PM25AQI.cpp
+++ b/Adafruit_PM25AQI.cpp
@@ -91,24 +91,29 @@ bool Adafruit_PM25AQI::read(PM25_AQI_Data *data) {
         return false;
       }
     }
-    if (serial_dev->read() != 0x42) { //read assuming you got the first byte
+    if (serial_dev->read() != 0x42) { // read assuming you got the first byte
       return false;
     }
-    //now catching 1 in 256 edge-case where last byte of checksum is 0x42 too, being mistaken for first start byte, leading to byte shift and checksum mismatch 
-    if (serial_dev->peek() == 0x42) { //peek if next byte might match first start byte
-      serial_dev->read(); // if yes last assumption was wrong, read again assuming you now got the start
+    // now catching 1 in 256 edge-case where last byte of checksum is 0x42 too,
+    // being mistaken for first start byte, leading to byte shift and checksum
+    // mismatch
+    if (serial_dev->peek() ==
+        0x42) {           // peek if next byte might match first start byte
+      serial_dev->read(); // if yes last assumption was wrong, read again
+                          // assuming you now got the start
     }
-    if (serial_dev->read() != 0x4d) { //read & check the second byte
+    if (serial_dev->read() != 0x4d) { // read & check the second byte
       return false;
     }
-    // Now the first two bytes are guaranteed to be 0x42 0x4d but have already been read
+    // Now the first two bytes are guaranteed to be 0x42 0x4d but have already
+    // been read
     buffer[0] = 0x42;
     buffer[1] = 0x4d;
     // Now read remaining 30 bytes
     if (serial_dev->available() < 30) {
       return false;
     }
-    for (uint8_t i=2; i<32; i++){
+    for (uint8_t i = 2; i < 32; i++) {
       buffer[i] = serial_dev->read();
     }
   } else {

--- a/Adafruit_PM25AQI.cpp
+++ b/Adafruit_PM25AQI.cpp
@@ -95,22 +95,22 @@ bool Adafruit_PM25AQI::read(PM25_AQI_Data *data) {
       return false;
     }
     //now catching 1 in 256 edge-case where last byte of checksum is 0x42 too, being mistaken for first start byte, leading to byte shift and checksum mismatch 
-	  if (serial_dev->peek() == 0x42) { //peek if next byte might match first start byte
+    if (serial_dev->peek() == 0x42) { //peek if next byte might match first start byte
       serial_dev->read(); // if yes last assumption was wrong, read again assuming you now got the start
     }
-	  if (serial_dev->read() != 0x4d) { //read & check the second byte
-	    return false;
+    if (serial_dev->read() != 0x4d) { //read & check the second byte
+      return false;
     }
-	  // Now the first two bytes are guaranteed to be 0x42 0x4d but have already been read
-	  buffer[0] = 0x42;
-	  buffer[1] = 0x4d;
+    // Now the first two bytes are guaranteed to be 0x42 0x4d but have already been read
+    buffer[0] = 0x42;
+    buffer[1] = 0x4d;
     // Now read remaining 30 bytes
     if (serial_dev->available() < 30) {
       return false;
     }
     for (uint8_t i=2; i<32; i++){
-		  buffer[i] = serial_dev->read();
-	  }
+      buffer[i] = serial_dev->read();
+    }
   } else {
     return false;
   }


### PR DESCRIPTION
If the last byte of the checksum is 0x42 it can be mistaken for the first start-byte, causing a byte-shift which leads to checksum mismatch followed by no ouput (continuously in the HEPA edge-case).
**Therefore checking the secondy start-byte is necessary.** 

The probability of this happening is 1 in 256 and in addition **it has 100% probability if testing HEPA-filtered air with 0 particles.**
Reason: With HEPA-filtered air all bytes are zero except:
start 1 + start 2 + frame-length + reserved
Decimal: 66 + 77 + 28 + 151 checksum: 256 + 66 
Hex: 0x42 0x4d 0x00 0x1c ... 0x97 checksum: 0x01 0x42
Testing with hepa-filtered air, an arduino nano, software serial (2,3) the byte-shift with continuous no-output happened repeatedly after less than 10 measurement cycles. With disabled checksum-check the 15 uint16_t components of data then look like this:
[Byte-shift.txt](https://github.com/adafruit/Adafruit_PM25AQI/files/5937582/Byte-shift.txt)

---- considering & disregarding further edge-cases ----
It is not possible for byte 31 (second checksum-byte) to be 0x42 too, as the sum of the first 30 bytes is at most 30*255 which is less than 66 * 256 which is the smallest checksum that would cause byte 31 to be 0x42 (=66).
**The sequence 0x42 0x42 0x42 0x4d with the last two being the start bytes is therefore impossible.**

Though it is not impossible for the sequence 0x42 0x42 0x4d or 0x42 0x4d to appear at another position in the sequence it can only happen with:

- particle count above 19712 = 77*256 and next finer particle count being equal to 66 mod 256
- particle count of precisely 16973 = 66*256 + 77

which is both really unlikely and very likely not a stable condition with a low chance of multiple byte-shift leading to checksum-mismatch and continuous no-output.