### PR TITLE
PM25 three second delay

### DIFF
--- a/examples/PM25_test/PM25_test.ino
+++ b/examples/PM25_test/PM25_test.ino
@@ -18,8 +18,8 @@ void setup() {
 
   Serial.println("Adafruit PMSA003I Air Quality Sensor");
 
-  // Wait one second for sensor to boot up!
-  delay(1000);
+  // Wait three seconds for sensor to boot up!
+  delay(3000);
 
   // If using serial, initialize it and set baudrate before starting!
   // Uncomment one of the following


### PR DESCRIPTION
Some controllers needed a little more of a delay before sensor initialization. The Feather ESP32-C6 was not detecting the sensor while the Feather RP2040 would.

This came out of a [forum issue](https://forums.adafruit.com/viewtopic.php?t=213468) @matthiasplum encountered. Adding a longer delay allowed the sensor to be detected and run as expected. Tested on a Feather RP2040 and ESP32-C6. 

